### PR TITLE
Fix: Exclude current active era from payout collection (services.ts)

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -139,7 +139,7 @@ export async function listPendingPayouts({
 		const controller = controllerOpt.unwrap();
 		// Check for unclaimed payouts from `current-eraDepth` to `current` era
 		// The current era is not claimable. Therefore we need to substract by 1.
-		for (let e = (currEra - 1) - eraDepth; e <= (currEra - 1); e++) {
+		for (let e = (currEra - 1) - eraDepth; e < (currEra - 1); e++) {
 			const payoutClaimed = await payoutClaimedForAddressForEra(api, controller.toString(), e);
 			if (payoutClaimed) {
 				continue;


### PR DESCRIPTION
Changed <= to < in the era loop to prevent attempting to claim payouts for the current active era, which causes "InvalidEraToReward" errors and prevents all payouts in the batch from being collected.